### PR TITLE
Don't do CNAME unwrapping for tracking requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckduckgo/privacy-grade",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckduckgo/privacy-grade",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "DuckDuckGo's privacy grade algorithm",
   "main": "index.js",
   "scripts": {

--- a/src/classes/trackers.js
+++ b/src/classes/trackers.js
@@ -115,10 +115,10 @@
                 urlToCheck = cnameResolution.finalURL
 
                 requestData.urlToCheck = urlToCheck
-                requestData.urlToCheckDomain = this.tldjs.parse(urlToCheck).domain,
+                requestData.urlToCheckDomain = this.tldjs.parse(urlToCheck).domain
                 requestData.urlToCheckSplit = this.utils.extractHostFromURL(urlToCheck).split('.')
                 tracker = this.findTracker(requestData)
-                
+
                 if (!tracker) {
                     return null
                 }

--- a/src/classes/trackers.js
+++ b/src/classes/trackers.js
@@ -109,7 +109,7 @@
             let tracker = this.findTracker(requestData)
 
             if (!tracker) {
-                // if request doesn't have any rules asociated with it, we should check if it's a CNAMEed tracker
+                // if request doesn't have any rules associated with it, we should check if it's a CNAMEed tracker
                 const cnameResolution = this.resolveCname(urlToCheck)
                 fromCname = cnameResolution.fromCname
                 urlToCheck = cnameResolution.finalURL


### PR DESCRIPTION
We found an edge-case where bad.tracker.com get CNAMEd to some.cdn.com and not blocked. See:
- https://app.asana.com/0/0/1201428985917574/1201428510929649/f
- and last comments in https://app.asana.com/0/0/1200328036456971/f