### PR TITLE
Change tldts to a non-dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@duckduckgo/privacy-grade",
       "version": "1.1.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "tldts": "^5.7.84"
+      },
       "devDependencies": {
         "chalk": "2.4.0",
         "commander": "2.15.1",
@@ -28,7 +31,6 @@
         "load-grunt-tasks": "3.5.2",
         "puppeteer": "12.0.0",
         "request": "2.85.0",
-        "tldts": "^5.7.84",
         "typescript": "^4.7.3",
         "url-parse-lax": "^3.0.0"
       }
@@ -6148,7 +6150,6 @@
       "version": "5.7.84",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-5.7.84.tgz",
       "integrity": "sha512-PGkhyObqEEntI/xUDJdagtvNW+O7+5j8vbXSOXL+563At8gH/4LHxHjdPNv7qrahYuL6y6ZgjBxcvWdut7/LtA==",
-      "dev": true,
       "dependencies": {
         "tldts-core": "^5.7.84"
       },
@@ -6159,8 +6160,7 @@
     "node_modules/tldts-core": {
       "version": "5.7.84",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.7.84.tgz",
-      "integrity": "sha512-1qKxwSDjmWdqG81cnXGvKI+FHPiVRT6w5DORjp2+YVqDdzFUZO0oQoWu0zbDtWA6HXVk+B15yY9DKbVKZ6fRLg==",
-      "dev": true
+      "integrity": "sha512-1qKxwSDjmWdqG81cnXGvKI+FHPiVRT6w5DORjp2+YVqDdzFUZO0oQoWu0zbDtWA6HXVk+B15yY9DKbVKZ6fRLg=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -11663,7 +11663,6 @@
       "version": "5.7.84",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-5.7.84.tgz",
       "integrity": "sha512-PGkhyObqEEntI/xUDJdagtvNW+O7+5j8vbXSOXL+563At8gH/4LHxHjdPNv7qrahYuL6y6ZgjBxcvWdut7/LtA==",
-      "dev": true,
       "requires": {
         "tldts-core": "^5.7.84"
       }
@@ -11671,8 +11670,7 @@
     "tldts-core": {
       "version": "5.7.84",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.7.84.tgz",
-      "integrity": "sha512-1qKxwSDjmWdqG81cnXGvKI+FHPiVRT6w5DORjp2+YVqDdzFUZO0oQoWu0zbDtWA6HXVk+B15yY9DKbVKZ6fRLg==",
-      "dev": true
+      "integrity": "sha512-1qKxwSDjmWdqG81cnXGvKI+FHPiVRT6w5DORjp2+YVqDdzFUZO0oQoWu0zbDtWA6HXVk+B15yY9DKbVKZ6fRLg=="
     },
     "tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   },
   "author": "",
   "license": "Apache-2.0",
+  "dependencies": {
+    "tldts": "^5.7.84"
+  },
   "devDependencies": {
     "chalk": "2.4.0",
     "commander": "2.15.1",
@@ -33,7 +36,6 @@
     "load-grunt-tasks": "3.5.2",
     "puppeteer": "12.0.0",
     "request": "2.85.0",
-    "tldts": "^5.7.84",
     "typescript": "^4.7.3",
     "url-parse-lax": "^3.0.0"
   }


### PR DESCRIPTION
Since tldts is imported by the JSDoc types in trackers.js, it needs to
be a dependency (as opposed to a dev dependency). Otherwise, packages
importing the JSDoc types from trackers.js will also need to add the
transient tldts dependency directly, even if they don't otherwise need
it.